### PR TITLE
Update composer.json to reflect minimum version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "php": "^7.2|^8.0",
+        "php": "^8.0",
         "contentful/core": "^3.0",
         "contentful/rich-text": "^3.1",
         "psr/cache": "^1.0|^2.0",


### PR DESCRIPTION
Since adding a `mixed` return type breaks the PHP 7.2 integration, remove it from the composer.json specification.

NOTE: This is a breaking change